### PR TITLE
Implement task runner for autonomous operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,20 @@ The `main.py` script defines a FastAPI application. If you want to run this sepa
     ```
     The API documentation will be available at `http://127.0.0.1:8000/docs`.
 
+### Autonomous Task Runner
+
+Use `task_runner.py` to run a list of queries without manual interaction. Tasks can be supplied with `--tasks` or a file via `--tasks-file`.
+
+Run serially (default):
+```bash
+python task_runner.py --tasks "What is the weather?" "Summarize news"
+```
+
+Run in parallel:
+```bash
+python task_runner.py --parallel --tasks-file tasks.txt --workers 4
+```
+
 ### Adding to Knowledge Base
 
 Place any `.txt` files you want JARVIS to learn from into the `docs/` directory. The system should automatically index them for retrieval when the `RAGAgent` or relevant memory functions are invoked.

--- a/task_runner.py
+++ b/task_runner.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+"""Utility to run multiple JARVIS tasks serially or in parallel."""
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Iterable, List
+
+from core.orchestrator import Orchestrator
+
+
+class TaskRunner:
+    """Run a series of queries autonomously with the Orchestrator."""
+
+    def __init__(self, workers: int = 4) -> None:
+        self.workers = max(1, workers)
+
+    def run_serial(self, tasks: Iterable[str]) -> List[str]:
+        orchestrator = Orchestrator()
+        results: List[str] = []
+        for task in tasks:
+            results.append(orchestrator.chat(task))
+        return results
+
+    def run_parallel(self, tasks: Iterable[str]) -> List[str]:
+        tasks = list(tasks)
+        results: List[str] = ["" for _ in tasks]
+
+        def _run(index: int, query: str) -> tuple[int, str]:
+            orchestrator = Orchestrator()
+            return index, orchestrator.chat(query)
+
+        with ThreadPoolExecutor(max_workers=self.workers) as executor:
+            futures = {executor.submit(_run, i, t): i for i, t in enumerate(tasks)}
+            for future in as_completed(futures):
+                idx, output = future.result()
+                results[idx] = output
+        return results
+
+
+def load_tasks_from_file(path: str) -> List[str]:
+    with open(path, "r", encoding="utf-8") as f:
+        return [line.strip() for line in f if line.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run JARVIS autonomously on a list of tasks"
+    )
+    parser.add_argument("--tasks", nargs="*", help="Tasks to process")
+    parser.add_argument("--tasks-file", help="File containing tasks, one per line")
+    parser.add_argument("--parallel", action="store_true", help="Run tasks in parallel")
+    parser.add_argument("--workers", type=int, default=4, help="Number of parallel workers")
+    args = parser.parse_args()
+
+    tasks: List[str] = []
+    if args.tasks_file:
+        tasks.extend(load_tasks_from_file(args.tasks_file))
+    if args.tasks:
+        tasks.extend(args.tasks)
+
+    if not tasks:
+        parser.error("No tasks provided via --tasks or --tasks-file")
+
+    runner = TaskRunner(workers=args.workers)
+    if args.parallel:
+        results = runner.run_parallel(tasks)
+    else:
+        results = runner.run_serial(tasks)
+
+    for task, result in zip(tasks, results):
+        print(f"TASK: {task}\nRESULT: {result}\n")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `task_runner.py` utility for running tasks serially or in parallel
- document the new tool in `README.md`

## Testing
- `python -m py_compile task_runner.py`
- `python -m py_compile agents/*.py core/*.py memory/*.py main.py agent.py`


------
https://chatgpt.com/codex/tasks/task_e_684091911e8083319da3f4135e6e733c